### PR TITLE
Better handling of callables

### DIFF
--- a/proof/analysis.py
+++ b/proof/analysis.py
@@ -10,6 +10,8 @@ analyses. Modifications made to ``data`` in the scope of one analysis will be
 propagated to all dependent analyses.
 """
 
+from __future__ import print_function
+
 import bz2
 from copy import deepcopy
 from glob import glob
@@ -19,10 +21,11 @@ import os
 
 try:
     import cPickle as pickle
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
     import pickle
 
 import six
+
 
 class Cache(object):
     """
@@ -59,6 +62,7 @@ class Cache(object):
         f.write(pickle.dumps(self._data))
         f.close()
 
+
 def never_cache(func):
     """
     Decorator to flag that a given analysis function should never be cached.
@@ -66,6 +70,7 @@ def never_cache(func):
     func.never_cache = True
 
     return func
+
 
 class Analysis(object):
     """
@@ -90,7 +95,9 @@ class Analysis(object):
         self._trace = _trace + [self]
         self._child_analyses = []
 
-        self._cache_path = os.path.join(self._cache_dir, '%s.cache' % self._fingerprint())
+        self._cache_path = os.path.join(
+            self._cache_dir, '%s.cache' % self._fingerprint()
+        )
         self._cache = Cache(self._cache_path)
 
         self._registered_cache_paths = []

--- a/proof/analysis.py
+++ b/proof/analysis.py
@@ -110,7 +110,13 @@ class Analysis(object):
 
         hasher.update(history)
 
-        source = inspect.getsource(self._func)
+        # self._func can be a callable object
+        if hasattr(self._func, '__call__'):
+            # get the source from the class
+            if hasattr(self._func, '__class__'):
+                source = inspect.getsource(self._func.__class__)
+        else:
+            source = inspect.getsource(self._func)
 
         # In Python 3 inspect.getsource returns unicode data
         if six.PY3:


### PR DESCRIPTION
Hello,

Instead to use a function, I prefer to write a class aiming a better description of my analysis rules. So, I defined a callable:

```python
class MyCallable(object):
    def __init__(self):
        # proof.Analysis will look for a dunder name attribute (duck typing)
        self.__name__ = self.__class__.__name__

    def __call__(self, data):
        # analysis rules
```

Then, I use it in the `Analysis.then` method:

```
import proof

analysis_one = MyCallable()
myproof = proof.Analysis(initial_data)

myproof.then(analysis_one)
```

The proof.Analisys._fingerprint is considering only functions and instead any callable like.

TL;DR I got this exception: https://github.com/python/cpython/blob/master/Lib/inspect.py#L624

I think this PR could be an initial step to a better way to handle callable in this method (_fingerprint).

P.S - I'm sorry if I broke some PR rule/template. I would be happy to discuss this point, improve this PR and write more tests if necessary.


